### PR TITLE
Turn off output on idle

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Check `raspdif --help` for additional optional arguments to tweak behavior.
 ```
 Usage: raspdif [OPTION...]
 
+  -d, --disable-pcm-on-idle  Disable PCM during underrun.
   -f, --format=FORMAT        Set audio sample format to s16le or s24le.
                              Default: s16le
   -i, --input=INPUT_FILE     Read data from file instead of stdin.

--- a/source/main.c
+++ b/source/main.c
@@ -46,7 +46,7 @@ static struct argp_option options[] = {
   {"rate", 'r', "RATE", 0, "Set audio sample rate. Default: 44.1 kHz"},
   {"format", 'f', "FORMAT", 0, "Set audio sample format to s16le or s24le. Default: s16le"},
   {"no-keep-alive", 'k', 0, 0, "Don't send silent noise during underrun."},
-  {"disable-pcm-on-idle", 'd', 0, 0, "Didable PCM during underrun."},
+  {"disable-pcm-on-idle", 'd', 0, 0, "Disable PCM during underrun."},
   {"verbose", 'v', 0, 0, "Enable debug messages."},
   {0},
 };
@@ -535,6 +535,7 @@ int main(int argc, char* argv[])
       if(arguments.pcm_disable)
       {
         bcm283x_pcm_enable(false, false);
+        LOGD(TAG, "PCM disabled.");
       }
       
       // Wait for file to be readable
@@ -546,6 +547,7 @@ int main(int argc, char* argv[])
       if(arguments.pcm_disable)
       {
         bcm283x_pcm_enable(true, false);
+        LOGD(TAG, "PCM enabled.");
       }
 
       // Resume read loop

--- a/source/main.c
+++ b/source/main.c
@@ -532,19 +532,19 @@ int main(int argc, char* argv[])
       // Zero fill the sample buffers for silence
       raspdif_fill_buffers(buffer_index, &block, arguments.format, arguments.sample_rate, arguments.keep_alive);
 
-      if(arguments.pcm_disable)
+      if (arguments.pcm_disable)
       {
         bcm283x_pcm_enable(false, false);
         LOGD(TAG, "PCM disabled.");
       }
-      
+
       // Wait for file to be readable
       struct pollfd poll_list;
       poll_list.fd = fileno(file);
       poll_list.events = POLLIN;
       poll(&poll_list, 1, -1);
 
-      if(arguments.pcm_disable)
+      if (arguments.pcm_disable)
       {
         bcm283x_pcm_enable(true, false);
         LOGD(TAG, "PCM enabled.");

--- a/source/main.c
+++ b/source/main.c
@@ -526,11 +526,15 @@ int main(int argc, char* argv[])
       // Zero fill the sample buffers for silence
       raspdif_fill_buffers(buffer_index, &block, arguments.format, arguments.sample_rate, arguments.keep_alive);
 
+      bcm283x_pcm_enable(false, false);
+
       // Wait for file to be readable
       struct pollfd poll_list;
       poll_list.fd = fileno(file);
       poll_list.events = POLLIN;
       poll(&poll_list, 1, -1);
+
+      bcm283x_pcm_enable(true, false);
 
       // Resume read loop
       LOGD(TAG, "Data available.");


### PR DESCRIPTION
Awesome job mill1000!
It works flawlessly on my setup :)

I ran into some small problem in my setup:
I'm using active speakers for a multi room setup.
SnapCast-Server -> SnapCast Client on Raspberry Pi Zero -> raspdif -> LED -> Toslink to my speakers.
My speakers are able to automatically activate on Toslink signal and deactivate themselves after 10s without signal.
BUT no signal means Toslink being turned off completely.
I realized in standard configuration, even with "no-keep-alive" the output never turns off, so my speakers are never going to sleep.

I've added a few lines to turn of PCM completely during buffer underrun, this solves my issue and my speakers are going to sleep.
Maybe this might help somebody else with a similar setup.

Thanks again for your amazing work, I really appreciate it!

Regards
Jens